### PR TITLE
Make color-var 2 files for better load sequence

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -18,7 +18,7 @@ Based on Underscores http://underscores.me/, (C) 2012-2017 Automattic, Inc.
 //-----------------------------------------
 // Harmonium Variables
 //-----------------------------------------
-// @import 'utilities/variables/color-palette';
+@import 'utilities/variables/color-palette';
 @import '../../node_modules/harmonium/scss/app';
 
 //-----------------------------------------

--- a/assets/sass/utilities/variables/_color-palette.scss
+++ b/assets/sass/utilities/variables/_color-palette.scss
@@ -1,0 +1,56 @@
+$test: #F0F;
+
+// BRAND COLORS
+$brand: #295DE5;
+$brand-secondary: #6422EB;
+$brand-tertiary: #501BBC;
+
+$white: #FFF;
+$lightest-gray: #F0F0F0;
+$lighter-gray: #D5D5D5;
+$light-gray: #ABABAB;
+$gray: #EBEAEA;
+$dark-gray: #565656;
+$darker-gray: #2A2A2A;
+$darkest-gray: #252525;
+$black: #000;
+
+$white-0: rgba(255, 255, 255, 0); // for animation purposes
+$white-03: rgba(255, 255, 255, 0.03);
+$white-06: rgba(255, 255, 255, 0.06);
+$white-10: rgba(255, 255, 255, 0.1);
+$white-20: rgba(255, 255, 255, 0.2);
+$white-30: rgba(255, 255, 255, 0.3);
+$white-40: rgba(255, 255, 255, 0.4);
+$white-50: rgba(255, 255, 255, 0.5);
+$white-60: rgba(255, 255, 255, 0.6);
+$white-70: rgba(255, 255, 255, 0.7);
+$white-80: rgba(255, 255, 255, 0.8);
+$white-90: rgba(255, 255, 255, 0.9);
+$black-0: rgba(0, 0, 0, 0); // for animation purposes
+$black-03: rgba(0, 0, 0, 0.03);
+$black-06: rgba(0, 0, 0, 0.06);
+$black-10: rgba(0, 0, 0, 0.1);
+$black-20: rgba(0, 0, 0, 0.2);
+$black-30: rgba(0, 0, 0, 0.3);
+$black-40: rgba(0, 0, 0, 0.4);
+$black-50: rgba(0, 0, 0, 0.5);
+$black-60: rgba(0, 0, 0, 0.6);
+$black-70: rgba(0, 0, 0, 0.7);
+$black-80: rgba(0, 0, 0, 0.8);
+$black-90: rgba(0, 0, 0, 0.9);
+
+// UTILITY COLORS
+$primary: $brand;
+$success: #00A67F;
+$alert: #D94011;
+$warning: #D10034;
+$error: #D10034;
+
+$divider-color: $black-10;
+$divider-color-dark: $black-20;
+$divider-color-light: $white-10;
+$muted: $lighter-gray;
+$very-muted: $lightest-gray;
+
+$disabled: $light-gray;

--- a/assets/sass/utilities/variables/_color-var.scss
+++ b/assets/sass/utilities/variables/_color-var.scss
@@ -33,30 +33,16 @@
 // COLOR VARIABLES
 //--------------------------------------------------------------
 
-//-----------------------------------------
-// Harmonium Base Colors
-//-----------------------------------------
-
-$test: #F0F;
-
-// BRAND COLORS
-$brand: #295DE5;
-$brand-secondary: #6422EB;
-$brand-tertiary: #501BBC;
-
-$white: #FFF;
-$lightest-gray: #F4F4F4;
-$lighter-gray: #D5D5D5;
-$light-gray: #ABABAB;
-$gray: #818181;
-$dark-gray: #565656;
-$darker-gray: #2A2A2A;
-$black: #000;
 
 //-----------------------------------------
 // Primary Colors
 //-----------------------------------------
-
+$color-brand-primary: $brand;
+$color-brand-secondary: $brand-secondary;
+$color-brand-tertiary: $brand-tertiary;
+$color-primary:      $brand;
+$color-secondary:    $brand-secondary;
+$color-tertiary:     $brand-tertiary;
 $color-black:        $black;
 $color-blue:         #20739a;
 $color-light-yellow: #fff9c0;
@@ -88,50 +74,6 @@ $color-pinterest: #cb2027;
 $color-rss:       #f90;
 $color-twitter:   #00aced;
 $color-youtube:   #b00;
-
-//-----------------------------------------
-// Additional Harmonium Colors
-//-----------------------------------------
-
-$white-0: rgba(255, 255, 255, 0); // for animation purposes
-$white-03: rgba(255, 255, 255, 0.03);
-$white-06: rgba(255, 255, 255, 0.06);
-$white-10: rgba(255, 255, 255, 0.1);
-$white-20: rgba(255, 255, 255, 0.2);
-$white-30: rgba(255, 255, 255, 0.3);
-$white-40: rgba(255, 255, 255, 0.4);
-$white-50: rgba(255, 255, 255, 0.5);
-$white-60: rgba(255, 255, 255, 0.6);
-$white-70: rgba(255, 255, 255, 0.7);
-$white-80: rgba(255, 255, 255, 0.8);
-$white-90: rgba(255, 255, 255, 0.9);
-$black-0: rgba(0, 0, 0, 0); // for animation purposes
-$black-03: rgba(0, 0, 0, 0.03);
-$black-06: rgba(0, 0, 0, 0.06);
-$black-10: rgba(0, 0, 0, 0.1);
-$black-20: rgba(0, 0, 0, 0.2);
-$black-30: rgba(0, 0, 0, 0.3);
-$black-40: rgba(0, 0, 0, 0.4);
-$black-50: rgba(0, 0, 0, 0.5);
-$black-60: rgba(0, 0, 0, 0.6);
-$black-70: rgba(0, 0, 0, 0.7);
-$black-80: rgba(0, 0, 0, 0.8);
-$black-90: rgba(0, 0, 0, 0.9);
-
-// UTILITY COLORS
-$primary: $brand;
-$success: #00A67F;
-$alert: #D94011;
-$warning: #D10034;
-$error: #D10034;
-
-$divider-color: $black-10;
-$divider-color-dark: $black-20;
-$divider-color-light: $white-10;
-$muted: $lighter-gray;
-$very-muted: $lightest-gray;
-
-$disabled: $light-gray;
 
 //--------------------------------------------------------------
 // ELEMENTS & SKINNING


### PR DESCRIPTION
This splits the color-var file into two files (color-var and color-palette). We tried to combine the two into 1 file, but then found that they need to be loaded at different times in the sequence so we are splitting it apart again.